### PR TITLE
Feltet referanseEksternNoekkel skal ikke være required i arkivmelding.xsd

### DIFF
--- a/KS.Fiks.IO.Arkiv.Client/Schema/arkivmelding.xsd
+++ b/KS.Fiks.IO.Arkiv.Client/Schema/arkivmelding.xsd
@@ -48,7 +48,7 @@
 
 			<xs:element name="klassifikasjon" type="klassifikasjon" minOccurs="0" maxOccurs="unbounded"/>
 
-      		<xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="1" maxOccurs="1"/>
+      		<xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0" maxOccurs="1"/>
       
 			<!-- Tillater mapper uten forekomster av (under)mappe og registrering -->
 			<xs:choice>


### PR DESCRIPTION
Ønsket om denne endringen ble tatt opp i møtet "ARBEIDSMØTE 3 – Pilotering av FIKS ARKIV (GI ARKIV 2.0)" 02.09.2021.

