### PR TITLE
Lagt til filnavn på dokumentobjekt

### DIFF
--- a/KS.Fiks.IO.Arkiv.Client/Schema/arkivmelding.xsd
+++ b/KS.Fiks.IO.Arkiv.Client/Schema/arkivmelding.xsd
@@ -263,6 +263,7 @@
 	<xs:complexType name="dokumentobjekt">
 		<xs:sequence>
 			<xs:element name="versjonsnummer" type="n5mdk:versjonsnummer"/>
+			<xs:element name="id" type="xs:string" minOccurs="1" maxOccurs="1"/>
 			<xs:element name="variantformat" type="n5mdk:variantformat"/>
 			<xs:element name="format" type="n5mdk:format"/>
 			<xs:element name="formatDetaljer" type="n5mdk:formatDetaljer" minOccurs="0"/>

--- a/KS.Fiks.IO.Arkiv.Client/Schema/arkivmelding.xsd
+++ b/KS.Fiks.IO.Arkiv.Client/Schema/arkivmelding.xsd
@@ -263,13 +263,13 @@
 	<xs:complexType name="dokumentobjekt">
 		<xs:sequence>
 			<xs:element name="versjonsnummer" type="n5mdk:versjonsnummer"/>
-			<xs:element name="id" type="xs:string" minOccurs="1" maxOccurs="1"/>
 			<xs:element name="variantformat" type="n5mdk:variantformat"/>
 			<xs:element name="format" type="n5mdk:format"/>
 			<xs:element name="formatDetaljer" type="n5mdk:formatDetaljer" minOccurs="0"/>
 			<xs:element name="mimeType" type="xs:string" minOccurs="0"/>
 			<xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0"/>
 			<xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
+			<xs:element name="filnavn" type="xs:string" minOccurs="1" maxOccurs="1"/>
 			<xs:element name="referanseDokumentfil" type="n5mdk:referanseDokumentfil"/>
 			<xs:element name="sjekksum" type="n5mdk:sjekksum" minOccurs="0"/>
 			<xs:element name="sjekksumAlgoritme" type="n5mdk:sjekksumAlgoritme" minOccurs="0"/>


### PR DESCRIPTION
Forslag til løsning på problem med filer og filnavn tatt opp på Slack:  

> _“Er det slik at dokumentbeskrivelse i arkivmeldingen kun identifiserer filer med filnavn?
> Hva med et ansettelsessystem som arkiverer en ansettelsessak med 10 journalposter for søknadene der hver journalpost har et hoveddokument med navn "søknad.pdf".
> Det vil vel ikke fungere?”_

Issue [#38](https://github.com/ks-no/fiks-arkiv/issues/38)
