### PR TITLE
Nye xsd filer for hent-meldinger

### DIFF
--- a/KS.Fiks.IO.Arkiv.Client.Integration.Tests/KS.Fiks.IO.Arkiv.Client.Integration.Tests/KS.Fiks.IO.Arkiv.Client.Integration.Tests.csproj
+++ b/KS.Fiks.IO.Arkiv.Client.Integration.Tests/KS.Fiks.IO.Arkiv.Client.Integration.Tests/KS.Fiks.IO.Arkiv.Client.Integration.Tests.csproj
@@ -6,7 +6,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="KS.Fiks.IO.Arkiv.Client" Version="2.0.2" />
+      <PackageReference Include="KS.Fiks.IO.Arkiv.Client" Version="2.0.4" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
       <PackageReference Include="NUnit" Version="3.13.2" />
       <PackageReference Include="NUnit.Runners" Version="3.12.0" />

--- a/KS.Fiks.IO.Arkiv.Client.Tests/GenererKodeFraXsdTester.cs
+++ b/KS.Fiks.IO.Arkiv.Client.Tests/GenererKodeFraXsdTester.cs
@@ -8,7 +8,8 @@ namespace KS.Fiks.IO.Arkiv.Client.Integration.Tests.SchemaTester
     [TestFixture]
     public class GenererKodeFraXsdTester
     {
-        [Test] 
+        [Test]
+        [Ignore("Kjøres manuelt ved behov da den ikke kan kjøres på Jenkins")]
         [TestCase("arkivmelding.xsd metadatakatalog.xsd /c /n:no.ks.fiks.io.arkivmelding")]
         [TestCase("arkivmeldingKvittering.xsd metadatakatalog.xsd /c /n:no.ks.fiks.io.arkivmelding.kvittering")]
         [TestCase("sok.xsd /c /n:no.ks.fiks.io.arkivmelding.sok")]

--- a/KS.Fiks.IO.Arkiv.Client/KS.Fiks.IO.Arkiv.Client.csproj
+++ b/KS.Fiks.IO.Arkiv.Client/KS.Fiks.IO.Arkiv.Client.csproj
@@ -61,6 +61,21 @@
           <Pack>true</Pack>
           <PackageCopyToOutput>true</PackageCopyToOutput>
       </Content>
+      <Content Include="Schema\dokumentfilHent.xsd">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        <Pack>true</Pack>
+        <PackageCopyToOutput>true</PackageCopyToOutput>
+      </Content>
+      <Content Include="Schema\journalpostHent.xsd">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        <Pack>true</Pack>
+        <PackageCopyToOutput>true</PackageCopyToOutput>
+      </Content>
+      <Content Include="Schema\mappeHent.xsd">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        <Pack>true</Pack>
+        <PackageCopyToOutput>true</PackageCopyToOutput>
+      </Content>
       <Content Include="Schema\metadatakatalog.xsd">
           <CopyToOutputDirectory>Always</CopyToOutputDirectory>
           <Pack>true</Pack>

--- a/KS.Fiks.IO.Arkiv.Client/Schema/arkivmelding.xsd
+++ b/KS.Fiks.IO.Arkiv.Client/Schema/arkivmelding.xsd
@@ -262,6 +262,7 @@
 
 	<xs:complexType name="dokumentobjekt">
 		<xs:sequence>
+			<xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
 			<xs:element name="versjonsnummer" type="n5mdk:versjonsnummer"/>
 			<xs:element name="variantformat" type="n5mdk:variantformat"/>
 			<xs:element name="format" type="n5mdk:format"/>

--- a/KS.Fiks.IO.Arkiv.Client/Schema/arkivmeldingKvittering.xsd
+++ b/KS.Fiks.IO.Arkiv.Client/Schema/arkivmeldingKvittering.xsd
@@ -23,7 +23,7 @@
 
 	<xs:complexType name="mappe">
 		<xs:sequence>
-			<xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
+			<xs:element name="systemID" type="n5mdk:systemID" minOccurs="1"/>
 			<xs:element name="mappeID" type="n5mdk:mappeID" minOccurs="0"/>
 			<xs:element minOccurs="0" name="ReferanseForeldermappe" type="n5mdk:systemID"/>
 			<xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0" />
@@ -52,7 +52,7 @@
 
 	<xs:complexType name="registrering">
 		<xs:sequence>
-			<xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
+			<xs:element name="systemID" type="n5mdk:systemID" minOccurs="1"/>
 			<xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0"/>
 			<xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
 			<xs:element name="arkivertDato" type="n5mdk:arkivertDato" minOccurs="0"/>
@@ -83,12 +83,19 @@
 
 	<xs:complexType name="dokumentbeskrivelse">
 		<xs:sequence>
-			<xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
+			<xs:element name="systemID" type="n5mdk:systemID" minOccurs="1"/>
 			<xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0"/>
 			<xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
+			<xs:element name="dokumentobjekt" type="dokumentobjekt" minOccurs="0" maxOccurs="unbounded"/>
 		</xs:sequence>
 	</xs:complexType>
 
+	<xs:complexType name="dokumentobjekt">
+		<xs:sequence>
+			<xs:element name="systemID" type="n5mdk:systemID" minOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+	
 	<xs:complexType name="eksternNoekkel">
 		<xs:sequence>
 			<xs:element name="fagsystem" type = "n5mdk:fagsystem"/>

--- a/KS.Fiks.IO.Arkiv.Client/Schema/arkivmeldingKvittering.xsd
+++ b/KS.Fiks.IO.Arkiv.Client/Schema/arkivmeldingKvittering.xsd
@@ -93,6 +93,8 @@
 	<xs:complexType name="dokumentobjekt">
 		<xs:sequence>
 			<xs:element name="systemID" type="n5mdk:systemID" minOccurs="1"/>
+			<xs:element name="opprettetDato" type="n5mdk:opprettetDato" minOccurs="0"/>
+			<xs:element name="opprettetAv" type="n5mdk:opprettetAv" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
 	

--- a/KS.Fiks.IO.Arkiv.Client/Schema/dokumentfilHent.xsd
+++ b/KS.Fiks.IO.Arkiv.Client/Schema/dokumentfilHent.xsd
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/dokumentfil/hent/v2"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:n5mdk="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+	targetNamespace="http://www.arkivverket.no/standarder/noark5/dokumentfil/hent/v2"
+	elementFormDefault="qualified">
+	<xs:import namespace="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+		schemaLocation="./metadatakatalog.xsd"/>
+
+	<xs:element name="dokumentfilHent" type="dokumentfilHent"/>
+	
+	<xs:complexType name="dokumentfilHent">
+		<xs:sequence>
+			<xs:element name="referanseDokumentfil" type="n5mdk:referanseDokumentfil"/>
+		</xs:sequence>
+	</xs:complexType>
+
+</xs:schema>

--- a/KS.Fiks.IO.Arkiv.Client/Schema/dokumentfilHent.xsd
+++ b/KS.Fiks.IO.Arkiv.Client/Schema/dokumentfilHent.xsd
@@ -11,8 +11,46 @@
 	
 	<xs:complexType name="dokumentfilHent">
 		<xs:sequence>
-			<xs:element name="referanseDokumentfil" type="n5mdk:referanseDokumentfil"/>
+			<xs:element name="dokumentfilNoekkel" type="dokumentfilNoekkel"/>
 		</xs:sequence>
 	</xs:complexType>
 
+	<xs:complexType name="dokumentfilNoekkel">
+		<xs:sequence>
+			<!-- hvis vi kan endre systemID til å være minOccurs="1" for returnert objekt i arkivmeldingKvittering så kan denne være alt man trenger? 
+			Eller kan man ikke garantere at den er unik? -->
+           <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
+           <xs:element name="registreringsID" type="n5mdk:registreringsID" minOccurs="0"/>
+			<!-- en fil må hentes ut i fra forelder + dokumentnummer og versjonsnummer slik jeg tolker arkivmelding? -->
+           <xs:element name="mappeNoekkel" type="mappeNoekkel" minOccurs="0"/> 
+           <xs:element name="journalpostNoekkel" type="journalpostNoekkel" minOccurs="0"/>
+           <xs:element name="dokumentnummer" type="n5mdk:dokumentnummer" minOccurs="0" maxOccurs="1"/>
+           <xs:element name="versjonsnummer" type="n5mdk:versjonsnummer" minOccurs="0" maxOccurs="1"/>
+       </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="mappeNoekkel">
+       <xs:sequence>
+           <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
+           <xs:element name="mappeID" type="n5mdk:mappeID" minOccurs="0"/>
+           <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0" maxOccurs="1"/>
+       </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="journalpostNoekkel">
+       <xs:sequence>
+           <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
+           <xs:element name="journalaar" type="n5mdk:journalaar" minOccurs="0"/>
+           <xs:element name="journalsekvensnummer" type="n5mdk:journalsekvensnummer" minOccurs="0"/>
+           <xs:element name="journalpostnummer" type="n5mdk:journalpostnummer" minOccurs="0"/>
+           <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0" maxOccurs="1"/>
+       </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="eksternNoekkel">
+       <xs:sequence>
+           <xs:element name="fagsystem" type = "n5mdk:fagsystem"/>
+           <xs:element name="noekkel" type = "n5mdk:noekkel"/>
+       </xs:sequence>
+   </xs:complexType>
 </xs:schema>

--- a/KS.Fiks.IO.Arkiv.Client/Schema/dokumentfilHent.xsd
+++ b/KS.Fiks.IO.Arkiv.Client/Schema/dokumentfilHent.xsd
@@ -17,40 +17,7 @@
 
 	<xs:complexType name="dokumentfilNoekkel">
 		<xs:sequence>
-			<!-- hvis vi kan endre systemID til å være minOccurs="1" for returnert objekt i arkivmeldingKvittering så kan denne være alt man trenger? 
-			Eller kan man ikke garantere at den er unik? -->
-           <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
-           <xs:element name="registreringsID" type="n5mdk:registreringsID" minOccurs="0"/>
-			<!-- en fil må hentes ut i fra forelder + dokumentnummer og versjonsnummer slik jeg tolker arkivmelding? -->
-           <xs:element name="mappeNoekkel" type="mappeNoekkel" minOccurs="0"/> 
-           <xs:element name="journalpostNoekkel" type="journalpostNoekkel" minOccurs="0"/>
-           <xs:element name="dokumentnummer" type="n5mdk:dokumentnummer" minOccurs="0" maxOccurs="1"/>
-           <xs:element name="versjonsnummer" type="n5mdk:versjonsnummer" minOccurs="0" maxOccurs="1"/>
-       </xs:sequence>
-   </xs:complexType>
-
-   <xs:complexType name="mappeNoekkel">
-       <xs:sequence>
-           <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
-           <xs:element name="mappeID" type="n5mdk:mappeID" minOccurs="0"/>
-           <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0" maxOccurs="1"/>
-       </xs:sequence>
-   </xs:complexType>
-
-   <xs:complexType name="journalpostNoekkel">
-       <xs:sequence>
-           <xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
-           <xs:element name="journalaar" type="n5mdk:journalaar" minOccurs="0"/>
-           <xs:element name="journalsekvensnummer" type="n5mdk:journalsekvensnummer" minOccurs="0"/>
-           <xs:element name="journalpostnummer" type="n5mdk:journalpostnummer" minOccurs="0"/>
-           <xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0" maxOccurs="1"/>
-       </xs:sequence>
-   </xs:complexType>
-
-   <xs:complexType name="eksternNoekkel">
-       <xs:sequence>
-           <xs:element name="fagsystem" type = "n5mdk:fagsystem"/>
-           <xs:element name="noekkel" type = "n5mdk:noekkel"/>
+           <xs:element name="systemID" type="n5mdk:systemID" minOccurs="1"/>
        </xs:sequence>
    </xs:complexType>
 </xs:schema>

--- a/KS.Fiks.IO.Arkiv.Client/Schema/journalpostHent.xsd
+++ b/KS.Fiks.IO.Arkiv.Client/Schema/journalpostHent.xsd
@@ -11,12 +11,15 @@
 	
 	<xs:complexType name="journalpostHent">
 		<xs:sequence>
+			<!-- hvis vi kan endre systemID til å være minOccurs="1" for returnert objekt i arkivmeldingKvittering så kan denne være alt man trenger? 
+			Eller kan man ikke garantere at den er unik?-->
+			<xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
 			<xs:element name="journalaar" type="n5mdk:journalaar" minOccurs="0"/>
-			<xs:element name="journalsekvensnummer" type="n5mdk:journalsekvensnummer"
-						minOccurs="0"/>
-			<xs:element name="journalpostnummer" type="n5mdk:journalpostnummer"
-						minOccurs="0"/>
-			<!-- Er det enten registreringsID eller de 3 overliggende feltene som kan identifisere en unik journalpost? -->
+			<xs:element name="journalsekvensnummer" type="n5mdk:journalsekvensnummer" minOccurs="0"/>
+			<xs:element name="journalpostnummer" type="n5mdk:journalpostnummer" minOccurs="0"/>
+			<!-- Er det enten referanseEksternNoekkel eller registreringsID eller de 3 overliggende feltene som kan identifisere en unik journalpost?
+			 Klarer vi å beskrive det at man trenger bare 1 av alternativene? -->
+			<xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0" maxOccurs="1"/>
 			<xs:element name="registreringsID" type="n5mdk:registreringsID" minOccurs="0"/>
 			<xs:element name="responsType" type="respons_type" minOccurs="1" maxOccurs="1" default="minimum"/>
 			<xs:element name="inkluder" type="inkluder" minOccurs="0" maxOccurs="1"/>
@@ -25,7 +28,7 @@
 
 	<xs:simpleType name="respons_type">
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="noekler"/> <!-- unødvendig da man allerede har nøklene? Eller kan det være man ønsker å hente "barnas" nøkler? --> 
+			<xs:enumeration value="noekler"/> 
 			<xs:enumeration value="minimum"/>
 			<xs:enumeration value="utvidet"/>
 		</xs:restriction>
@@ -48,4 +51,10 @@
 		</xs:restriction>
 	</xs:simpleType>
 
+	<xs:complexType name="eksternNoekkel">
+		<xs:sequence>
+			<xs:element name="fagsystem" type = "n5mdk:fagsystem"/>
+			<xs:element name="noekkel" type = "n5mdk:noekkel"/>
+		</xs:sequence>
+	</xs:complexType>
 </xs:schema>

--- a/KS.Fiks.IO.Arkiv.Client/Schema/journalpostHent.xsd
+++ b/KS.Fiks.IO.Arkiv.Client/Schema/journalpostHent.xsd
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/journalpost/hent/v2"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:n5mdk="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+	targetNamespace="http://www.arkivverket.no/standarder/noark5/journalpost/hent/v2"
+	elementFormDefault="qualified">
+	<xs:import namespace="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+		schemaLocation="./metadatakatalog.xsd"/>
+
+	<xs:element name="journalpostHent" type="journalpostHent"/>
+	
+	<xs:complexType name="journalpostHent">
+		<xs:sequence>
+			<xs:element name="journalaar" type="n5mdk:journalaar" minOccurs="0"/>
+			<xs:element name="journalsekvensnummer" type="n5mdk:journalsekvensnummer"
+						minOccurs="0"/>
+			<xs:element name="journalpostnummer" type="n5mdk:journalpostnummer"
+						minOccurs="0"/>
+			<!-- Er det enten registreringsID eller de 3 overliggende feltene som kan identifisere en unik journalpost? -->
+			<xs:element name="registreringsID" type="n5mdk:registreringsID" minOccurs="0"/>
+			<xs:element name="responsType" type="respons_type" minOccurs="1" maxOccurs="1" default="minimum"/>
+			<xs:element name="inkluder" type="inkluder" minOccurs="0" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:simpleType name="respons_type">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="noekler"/> <!-- unødvendig da man allerede har nøklene? Eller kan det være man ønsker å hente "barnas" nøkler? --> 
+			<xs:enumeration value="minimum"/>
+			<xs:enumeration value="utvidet"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="inkluder">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="klasse"/>
+			<xs:enumeration value="noekkelord"/>
+			<xs:enumeration value="kryssreferanse"/>
+			<xs:enumeration value="part"/>
+			<xs:enumeration value="merknad"/>
+			<xs:enumeration value="presedens"/>
+			<xs:enumeration value="moetedeltaker"/>
+			<xs:enumeration value="dokumentbeskrivelse"/>
+			<xs:enumeration value="korrespondansepart"/>
+			<xs:enumeration value="avskrivning"/>
+			<xs:enumeration value="dokumentflyt"/>
+			<xs:enumeration value="dokumentobjekt"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+</xs:schema>

--- a/KS.Fiks.IO.Arkiv.Client/Schema/mappeHent.xsd
+++ b/KS.Fiks.IO.Arkiv.Client/Schema/mappeHent.xsd
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns="http://www.arkivverket.no/standarder/noark5/mappe/hent/v2"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema"
+	xmlns:n5mdk="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+	targetNamespace="http://www.arkivverket.no/standarder/noark5/mappe/hent/v2"
+	elementFormDefault="qualified">
+	<xs:import namespace="http://www.arkivverket.no/standarder/noark5/metadatakatalog/v2"
+		schemaLocation="./metadatakatalog.xsd"/>
+
+	<xs:element name="mappeHent" type="mappeHent"/>
+	
+	<xs:complexType name="mappeHent">
+		<xs:sequence>
+			<xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
+			<xs:element name="mappeID" type="n5mdk:mappeID" minOccurs="0"/>
+			<xs:element name="responsType" type="respons_type" minOccurs="1" maxOccurs="1" default="minimum"/>
+			<xs:element name="inkluder" type="inkluder" minOccurs="0" maxOccurs="1"/>
+		</xs:sequence>
+	</xs:complexType>
+
+	<xs:simpleType name="respons_type">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="noekler"/> <!-- unødvendig da man allerede har nøklene? Eller kan det være man ønsker å hente "barnas" nøkler? -->
+			<xs:enumeration value="minimum"/>
+			<xs:enumeration value="utvidet"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+	<xs:simpleType name="inkluder">
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="mappe"/>
+			<xs:enumeration value="registrering"/>
+			<xs:enumeration value="klasse"/>
+			<xs:enumeration value="noekkelord"/>
+			<xs:enumeration value="kryssreferanse"/>
+			<xs:enumeration value="part"/>
+			<xs:enumeration value="merknad"/>
+			<xs:enumeration value="presedens"/>
+			<xs:enumeration value="moetedeltaker"/>
+			<xs:enumeration value="dokumentbeskrivelse"/>
+			<xs:enumeration value="korrespondansepart"/>
+			<xs:enumeration value="avskrivning"/>
+			<xs:enumeration value="dokumentflyt"/>
+			<xs:enumeration value="dokumentobjekt"/>
+		</xs:restriction>
+	</xs:simpleType>
+
+</xs:schema>

--- a/KS.Fiks.IO.Arkiv.Client/Schema/mappeHent.xsd
+++ b/KS.Fiks.IO.Arkiv.Client/Schema/mappeHent.xsd
@@ -11,8 +11,13 @@
 	
 	<xs:complexType name="mappeHent">
 		<xs:sequence>
+			<!-- hvis vi kan endre systemID til å være minOccurs="1" for returnert objekt i arkivmeldingKvittering så kan denne være alt man trenger? 
+			Eller kan man ikke garantere at den er unik?-->
 			<xs:element name="systemID" type="n5mdk:systemID" minOccurs="0"/>
 			<xs:element name="mappeID" type="n5mdk:mappeID" minOccurs="0"/>
+			<xs:element name="referanseEksternNoekkel" type="eksternNoekkel" minOccurs="0" maxOccurs="1"/>
+			<!-- Er det enten referanseEksternNoekkel eller mappeID som kan identifisere en unik mappe?
+			Klarer vi å beskrive det at man trenger bare 1 av 2? -->
 			<xs:element name="responsType" type="respons_type" minOccurs="1" maxOccurs="1" default="minimum"/>
 			<xs:element name="inkluder" type="inkluder" minOccurs="0" maxOccurs="1"/>
 		</xs:sequence>
@@ -20,7 +25,7 @@
 
 	<xs:simpleType name="respons_type">
 		<xs:restriction base="xs:string">
-			<xs:enumeration value="noekler"/> <!-- unødvendig da man allerede har nøklene? Eller kan det være man ønsker å hente "barnas" nøkler? -->
+			<xs:enumeration value="noekler"/>
 			<xs:enumeration value="minimum"/>
 			<xs:enumeration value="utvidet"/>
 		</xs:restriction>
@@ -45,4 +50,10 @@
 		</xs:restriction>
 	</xs:simpleType>
 
+	<xs:complexType name="eksternNoekkel">
+		<xs:sequence>
+			<xs:element name="fagsystem" type = "n5mdk:fagsystem"/>
+			<xs:element name="noekkel" type = "n5mdk:noekkel"/>
+		</xs:sequence>
+	</xs:complexType>
 </xs:schema>


### PR DESCRIPTION
Xsd schemas for henting av journalpost, mappe og dokumentfil. 

Men burde vi ikke kunne bruke systemID for henting av disse 3 elementene som hoved identifikator?
Altså at arkivmeldingKvittering.xsd og sokeresultat skal ha minOccurs="1" på systemID slik at man kan bruke denne som referanse ved henting av objekter?

Dette er forslag på løsning til [issue 47](https://github.com/ks-no/fiks-arkiv/issues/47)