### PR TITLE
Nye meldinstyper og renamet de gamle

### DIFF
--- a/KS.Fiks.IO.Arkiv.Client/Models/ArkivintegrasjonMeldingTypeV1.cs
+++ b/KS.Fiks.IO.Arkiv.Client/Models/ArkivintegrasjonMeldingTypeV1.cs
@@ -18,6 +18,8 @@ namespace KS.Fiks.IO.Arkiv.Client.Models
         // Sok
         public const string Sok = "no.ks.fiks.gi.arkivintegrasjon.v1.sok";
         public const string SokResultat = "no.ks.fiks.gi.arkivintegrasjon.v1.sok.resultat";
+        public const string SokResultatMinimum = "no.ks.fiks.gi.arkivintegrasjon.v1.sok.resultat.minimum";
+        public const string SokResultatNoekler = "no.ks.fiks.gi.arkivintegrasjon.v1.sok.resultat.noekler";
         
         // Komplett
         public const string KomplettArkivmelding = "no.ks.fiks.gi.arkivintegrasjon.v1.komplett.arkivmelding";
@@ -35,7 +37,9 @@ namespace KS.Fiks.IO.Arkiv.Client.Models
         public static readonly List<string> SokTyper = new List<string>()
         {
             Sok,
-            SokResultat
+            SokResultat,
+            SokResultatMinimum,
+            SokResultatNoekler
         };
 
         public static readonly List<string> KompletteTyper = new List<string>()

--- a/KS.Fiks.IO.Arkiv.Client/Models/ArkivintegrasjonMeldingTypeV1.cs
+++ b/KS.Fiks.IO.Arkiv.Client/Models/ArkivintegrasjonMeldingTypeV1.cs
@@ -5,25 +5,28 @@ namespace KS.Fiks.IO.Arkiv.Client.Models
     public static class ArkivintegrasjonMeldingTypeV1
     {
         // Arkivintegrasjon mottaksmelding og kvitteringsmelding
-        public const string Mottatt = "no.ks.fiks.gi.arkivintegrasjon.v1.mottatt";
-        public const string Kvittering = "no.ks.fiks.gi.arkivintegrasjon.v1.kvittering";
+        public const string Mottatt = "no.ks.fiks.arkiv.v1.mottatt";
+        public const string Kvittering = "no.ks.fiks.arkiv.v1.kvittering";
         
         // Basis
-        public const string BasisArkivmelding = "no.ks.fiks.gi.arkivintegrasjon.v1.basis.arkivmelding";
-        public const string BasisSaksmappeOppdater = "no.ks.fiks.gi.arkivintegrasjon.v1.basis.saksmappe.oppdater";
-        public const string BasisMappeHent= "no.ks.fiks.gi.arkivintegrasjon.v1.basis.mappe.hent";
-        public const string BasisJournalpostHent = "no.ks.fiks.gi.arkivintegrasjon.v1.basis.journalpost.hent";
-        public const string BasisDokumentfilHent = "no.ks.fiks.gi.arkivintegrasjon.v1.basis.dokumentfil.hent";
+        public const string BasisArkivmelding = "no.ks.fiks.arkiv.v1.basis.arkivmelding";
+        public const string BasisSaksmappeOppdater = "no.ks.fiks.arkiv.v1.basis.saksmappe.oppdater";
+        public const string BasisMappeHent = "no.ks.fiks.arkiv.v1.basis.mappe.hent";
+        public const string BasisMappeHentResultat = "no.ks.fiks.arkiv.v1.basis.mappe.hent.resultat";
+        public const string BasisJournalpostHent = "no.ks.fiks.arkiv.v1.basis.journalpost.hent";
+        public const string BasisJournalpostHentResultat = "no.ks.fiks.arkiv.v1.basis.journalpost.hent.resultat";
+        public const string BasisDokumentfilHent = "no.ks.fiks.arkiv.v1.basis.dokumentfil.hent";
+        public const string BasisDokumentfilHentResultat = "no.ks.fiks.arkiv.v1.basis.dokumentfil.hent.resultat";
         
         // Sok
-        public const string Sok = "no.ks.fiks.gi.arkivintegrasjon.v1.sok";
-        public const string SokResultat = "no.ks.fiks.gi.arkivintegrasjon.v1.sok.resultat";
-        public const string SokResultatMinimum = "no.ks.fiks.gi.arkivintegrasjon.v1.sok.resultat.minimum";
-        public const string SokResultatNoekler = "no.ks.fiks.gi.arkivintegrasjon.v1.sok.resultat.noekler";
+        public const string Sok = "no.ks.fiks.arkiv.v1.sok";
+        public const string SokResultatUtvidet = "no.ks.fiks.arkiv.v1.sok.resultat.utvidet";
+        public const string SokResultatMinimum = "no.ks.fiks.arkiv.v1.sok.resultat.minimum";
+        public const string SokResultatNoekler = "no.ks.fiks.arkiv.v1.sok.resultat.noekler";
         
         // Komplett
-        public const string KomplettArkivmelding = "no.ks.fiks.gi.arkivintegrasjon.v1.komplett.arkivmelding";
-        public const string KomplettArkivmeldingUtgaaende = "no.ks.fiks.gi.arkivintegrasjon.v1.komplett.arkivmeldingUtgaaende";
+        public const string KomplettArkivmelding = "no.ks.fiks.arkiv.v1.komplett.arkivmelding";
+        public const string KomplettArkivmeldingUtgaaende = "no.ks.fiks.arkiv.v1.komplett.arkivmeldingUtgaaende";
         
         public static readonly List<string> BasisTyper = new List<string>()
         {
@@ -37,7 +40,7 @@ namespace KS.Fiks.IO.Arkiv.Client.Models
         public static readonly List<string> SokTyper = new List<string>()
         {
             Sok,
-            SokResultat,
+            SokResultatUtvidet,
             SokResultatMinimum,
             SokResultatNoekler
         };

--- a/KS.Fiks.IO.Arkiv.Client/Models/ArkivintegrasjonMeldingTypeV1.cs
+++ b/KS.Fiks.IO.Arkiv.Client/Models/ArkivintegrasjonMeldingTypeV1.cs
@@ -8,33 +8,30 @@ namespace KS.Fiks.IO.Arkiv.Client.Models
         public const string Mottatt = "no.ks.fiks.arkiv.v1.mottatt";
         public const string Kvittering = "no.ks.fiks.arkiv.v1.kvittering";
         
-        // Basis
-        public const string BasisArkivmelding = "no.ks.fiks.arkiv.v1.basis.arkivmelding";
-        public const string BasisSaksmappeOppdater = "no.ks.fiks.arkiv.v1.basis.saksmappe.oppdater";
-        public const string BasisMappeHent = "no.ks.fiks.arkiv.v1.basis.mappe.hent";
-        public const string BasisMappeHentResultat = "no.ks.fiks.arkiv.v1.basis.mappe.hent.resultat";
-        public const string BasisJournalpostHent = "no.ks.fiks.arkiv.v1.basis.journalpost.hent";
-        public const string BasisJournalpostHentResultat = "no.ks.fiks.arkiv.v1.basis.journalpost.hent.resultat";
-        public const string BasisDokumentfilHent = "no.ks.fiks.arkiv.v1.basis.dokumentfil.hent";
-        public const string BasisDokumentfilHentResultat = "no.ks.fiks.arkiv.v1.basis.dokumentfil.hent.resultat";
+        // Arkivmeldinger
+        public const string Arkivmelding = "no.ks.fiks.arkiv.v1.arkivmelding";
+        public const string MappeHent = "no.ks.fiks.arkiv.v1.mappe.hent";
+        public const string MappeHentResultat = "no.ks.fiks.arkiv.v1.mappe.hent.resultat";
+        public const string JournalpostHent = "no.ks.fiks.arkiv.v1.journalpost.hent";
+        public const string JournalpostHentResultat = "no.ks.fiks.arkiv.v1.journalpost.hent.resultat";
+        public const string DokumentfilHent = "no.ks.fiks.arkiv.v1.dokumentfil.hent";
+        public const string DokumentfilHentResultat = "no.ks.fiks.arkiv.v1.dokumentfil.hent.resultat";
         
         // Sok
         public const string Sok = "no.ks.fiks.arkiv.v1.sok";
         public const string SokResultatUtvidet = "no.ks.fiks.arkiv.v1.sok.resultat.utvidet";
         public const string SokResultatMinimum = "no.ks.fiks.arkiv.v1.sok.resultat.minimum";
         public const string SokResultatNoekler = "no.ks.fiks.arkiv.v1.sok.resultat.noekler";
-        
-        // Komplett
-        public const string KomplettArkivmelding = "no.ks.fiks.arkiv.v1.komplett.arkivmelding";
-        public const string KomplettArkivmeldingUtgaaende = "no.ks.fiks.arkiv.v1.komplett.arkivmeldingUtgaaende";
-        
-        public static readonly List<string> BasisTyper = new List<string>()
+          
+        public static readonly List<string> ArkivmeldingTyper = new List<string>()
         {
-            BasisArkivmelding,
-            BasisMappeHent,
-            BasisJournalpostHent,
-            BasisDokumentfilHent,
-            BasisSaksmappeOppdater
+            Arkivmelding,
+            MappeHent,
+            MappeHentResultat,
+            JournalpostHent,
+            JournalpostHentResultat,
+            DokumentfilHent,
+            DokumentfilHentResultat
         };
             
         public static readonly List<string> SokTyper = new List<string>()
@@ -45,25 +42,14 @@ namespace KS.Fiks.IO.Arkiv.Client.Models
             SokResultatNoekler
         };
 
-        public static readonly List<string> KompletteTyper = new List<string>()
+        public static bool IsArkivmeldingType(string meldingsType)
         {
-            KomplettArkivmelding,
-            KomplettArkivmeldingUtgaaende
-        };
-
-        public static bool IsBasis(string meldingsType)
-        {
-            return BasisTyper.Contains(meldingsType);
+            return ArkivmeldingTyper.Contains(meldingsType);
         }
 
-        public static bool IsSok(string meldingsType)
+        public static bool IsSokType(string meldingsType)
         {
             return SokTyper.Contains(meldingsType);
-        }
-        
-        public static bool IsKomplett(string meldingsType)
-        { 
-            return KompletteTyper.Contains(meldingsType);
         }
     }
 }

--- a/KS.Fiks.IO.Arkiv.Client/Models/ArkivintegrasjonMeldingTypeV1.cs
+++ b/KS.Fiks.IO.Arkiv.Client/Models/ArkivintegrasjonMeldingTypeV1.cs
@@ -5,56 +5,58 @@ namespace KS.Fiks.IO.Arkiv.Client.Models
     public static class ArkivintegrasjonMeldingTypeV1
     {
         // Arkivintegrasjon mottaksmelding og kvitteringsmelding
-        public const string Mottatt = "no.ks.fiks.gi.arkivintegrasjon.mottatt.v1";
-        public const string Kvittering = "no.ks.fiks.gi.arkivintegrasjon.kvittering.v1";
+        public const string Mottatt = "no.ks.fiks.gi.arkivintegrasjon.v1.mottatt";
+        public const string Kvittering = "no.ks.fiks.gi.arkivintegrasjon.v1.kvittering";
         
         // Basis
-        public const string BasisArkivmelding = "no.ks.fiks.gi.arkivintegrasjon.oppdatering.basis.arkivmelding.v1";
-        //public const string BasisArkivmeldingUtgaaende = "no.ks.fiks.gi.arkivintegrasjon.oppdatering.basis.arkivmeldingUtgaaende.v1";
-        //public const string ForenkletArkivmeldingInnkommende = "no.ks.fiks.gi.arkivintegrasjon.oppdatering.forenklet.arkivmeldingInnkommende.v1";
-        public const string BasisOppdaterSaksmappe = "no.ks.fiks.gi.arkivintegrasjon.oppdatering.basis.oppdatersaksmappe.v1";
+        public const string BasisArkivmelding = "no.ks.fiks.gi.arkivintegrasjon.v1.basis.arkivmelding";
+        public const string BasisSaksmappeOppdater = "no.ks.fiks.gi.arkivintegrasjon.v1.basis.saksmappe.oppdater";
+        public const string BasisMappeHent= "no.ks.fiks.gi.arkivintegrasjon.v1.basis.mappe.hent";
+        public const string BasisJournalpostHent = "no.ks.fiks.gi.arkivintegrasjon.v1.basis.journalpost.hent";
+        public const string BasisDokumentfilHent = "no.ks.fiks.gi.arkivintegrasjon.v1.basis.dokumentfil.hent";
         
         // Sok
-        public const string InnsynSok = "no.ks.fiks.gi.arkivintegrasjon.innsyn.sok.v1";
-        public const string InnsynSokResultat = "no.ks.fiks.gi.arkivintegrasjon.innsyn.sok.resultat.v1";
+        public const string Sok = "no.ks.fiks.gi.arkivintegrasjon.v1.sok";
+        public const string SokResultat = "no.ks.fiks.gi.arkivintegrasjon.v1.sok.resultat";
         
-        // Avansert
-        //public const string OppdateringArkivmelding = "no.ks.fiks.gi.arkivintegrasjon.oppdatering.arkivmelding.v1";
-        //public const string OppdateringArkivmeldingUtgaaende = "no.ks.fiks.gi.arkivintegrasjon.oppdatering.arkivmeldingUtgaaende.v1";
+        // Komplett
+        public const string KomplettArkivmelding = "no.ks.fiks.gi.arkivintegrasjon.v1.komplett.arkivmelding";
+        public const string KomplettArkivmeldingUtgaaende = "no.ks.fiks.gi.arkivintegrasjon.v1.komplett.arkivmeldingUtgaaende";
         
-        public static readonly List<string> Basis = new List<string>()
+        public static readonly List<string> BasisTyper = new List<string>()
         {
             BasisArkivmelding,
-            //BasisArkivmeldingUtgaaende,
-            //ForenkletArkivmeldingInnkommende,
-            BasisOppdaterSaksmappe
+            BasisMappeHent,
+            BasisJournalpostHent,
+            BasisDokumentfilHent,
+            BasisSaksmappeOppdater
         };
             
-        public static readonly List<string> Sok = new List<string>()
+        public static readonly List<string> SokTyper = new List<string>()
         {
-            InnsynSok,
-            //InnsynSokResultat
+            Sok,
+            SokResultat
         };
 
-        public static readonly List<string> Avansert = new List<string>()
+        public static readonly List<string> KompletteTyper = new List<string>()
         {
-            //OppdateringArkivmelding,
-            //OppdateringArkivmeldingUtgaaende
+            KomplettArkivmelding,
+            KomplettArkivmeldingUtgaaende
         };
 
         public static bool IsBasis(string meldingsType)
         {
-            return Basis.Contains(meldingsType);
+            return BasisTyper.Contains(meldingsType);
         }
 
         public static bool IsSok(string meldingsType)
         {
-            return Sok.Contains(meldingsType);
+            return SokTyper.Contains(meldingsType);
         }
         
-        public static bool IsAvansert(string meldingsType)
+        public static bool IsKomplett(string meldingsType)
         { 
-            return Avansert.Contains(meldingsType);
+            return KompletteTyper.Contains(meldingsType);
         }
     }
 }


### PR DESCRIPTION
Har endret litt på navnene som var for å bedre vise hvilken versjon av protokollen de tilhører samt forenklet litt navnestandarden. På samme måte som for `politisk.behandling` protokollen.

Nye meldingstyper for hent-meldinger er lagt til også.

Det som heter "basis", er det egentlig "forenklet"?
Og da "avansert" burde blir "komplett"?