### PR TITLE
Gjenninførte innsyn begrep på søk

### DIFF
--- a/KS.Fiks.IO.Arkiv.Client/Models/ArkivintegrasjonMeldingTypeV1.cs
+++ b/KS.Fiks.IO.Arkiv.Client/Models/ArkivintegrasjonMeldingTypeV1.cs
@@ -4,12 +4,10 @@ namespace KS.Fiks.IO.Arkiv.Client.Models
 {
     public static class ArkivintegrasjonMeldingTypeV1
     {
-        // Arkivintegrasjon mottaksmelding og kvitteringsmelding
-        public const string Mottatt = "no.ks.fiks.arkiv.v1.mottatt";
-        public const string Kvittering = "no.ks.fiks.arkiv.v1.kvittering";
-        
         // Arkivering
         public const string Arkivmelding = "no.ks.fiks.arkiv.v1.arkivering.arkivmelding";
+        public const string ArkivmeldingMottatt = "no.ks.fiks.arkiv.v1.arkivering.arkivmelding.mottatt";
+        public const string ArkivmeldingKvittering = "no.ks.fiks.arkiv.v1.arkivering.arkivmelding.kvittering";
         
         // Innsyn Hent
         public const string MappeHent = "no.ks.fiks.arkiv.v1.innsyn.mappe.hent";
@@ -27,7 +25,9 @@ namespace KS.Fiks.IO.Arkiv.Client.Models
           
         public static readonly List<string> ArkiveringTyper = new List<string>()
         {
-            Arkivmelding
+            Arkivmelding,
+            ArkivmeldingMottatt,
+            ArkivmeldingKvittering
         };
             
         public static readonly List<string> InnsynTyper = new List<string>()

--- a/KS.Fiks.IO.Arkiv.Client/Models/ArkivintegrasjonMeldingTypeV1.cs
+++ b/KS.Fiks.IO.Arkiv.Client/Models/ArkivintegrasjonMeldingTypeV1.cs
@@ -8,8 +8,10 @@ namespace KS.Fiks.IO.Arkiv.Client.Models
         public const string Mottatt = "no.ks.fiks.arkiv.v1.mottatt";
         public const string Kvittering = "no.ks.fiks.arkiv.v1.kvittering";
         
-        // Arkivmeldinger
+        // Arkivmelding
         public const string Arkivmelding = "no.ks.fiks.arkiv.v1.arkivmelding";
+        
+        //Hent
         public const string MappeHent = "no.ks.fiks.arkiv.v1.mappe.hent";
         public const string MappeHentResultat = "no.ks.fiks.arkiv.v1.mappe.hent.resultat";
         public const string JournalpostHent = "no.ks.fiks.arkiv.v1.journalpost.hent";
@@ -23,33 +25,34 @@ namespace KS.Fiks.IO.Arkiv.Client.Models
         public const string SokResultatMinimum = "no.ks.fiks.arkiv.v1.innsyn.sok.resultat.minimum";
         public const string SokResultatNoekler = "no.ks.fiks.arkiv.v1.innsyn.sok.resultat.noekler";
           
-        public static readonly List<string> ArkivmeldingTyper = new List<string>()
+        public static readonly List<string> ArkiveringTyper = new List<string>()
         {
-            Arkivmelding,
+            Arkivmelding
+        };
+            
+        public static readonly List<string> InnsynTyper = new List<string>()
+        {
+            Sok,
+            SokResultatUtvidet,
+            SokResultatMinimum,
+            SokResultatNoekler,
             MappeHent,
             MappeHentResultat,
             JournalpostHent,
             JournalpostHentResultat,
             DokumentfilHent,
             DokumentfilHentResultat
-        };
             
-        public static readonly List<string> SokTyper = new List<string>()
-        {
-            Sok,
-            SokResultatUtvidet,
-            SokResultatMinimum,
-            SokResultatNoekler
         };
 
-        public static bool IsArkivmeldingType(string meldingsType)
+        public static bool IsArkiveringType(string meldingsType)
         {
-            return ArkivmeldingTyper.Contains(meldingsType);
+            return ArkiveringTyper.Contains(meldingsType);
         }
 
-        public static bool IsSokType(string meldingsType)
+        public static bool IsInnsynType(string meldingsType)
         {
-            return SokTyper.Contains(meldingsType);
+            return InnsynTyper.Contains(meldingsType);
         }
     }
 }

--- a/KS.Fiks.IO.Arkiv.Client/Models/ArkivintegrasjonMeldingTypeV1.cs
+++ b/KS.Fiks.IO.Arkiv.Client/Models/ArkivintegrasjonMeldingTypeV1.cs
@@ -18,10 +18,10 @@ namespace KS.Fiks.IO.Arkiv.Client.Models
         public const string DokumentfilHentResultat = "no.ks.fiks.arkiv.v1.dokumentfil.hent.resultat";
         
         // Sok
-        public const string Sok = "no.ks.fiks.arkiv.v1.sok";
-        public const string SokResultatUtvidet = "no.ks.fiks.arkiv.v1.sok.resultat.utvidet";
-        public const string SokResultatMinimum = "no.ks.fiks.arkiv.v1.sok.resultat.minimum";
-        public const string SokResultatNoekler = "no.ks.fiks.arkiv.v1.sok.resultat.noekler";
+        public const string Sok = "no.ks.fiks.arkiv.v1.innsyn.sok";
+        public const string SokResultatUtvidet = "no.ks.fiks.arkiv.v1.innsyn.sok.resultat.utvidet";
+        public const string SokResultatMinimum = "no.ks.fiks.arkiv.v1.innsyn.sok.resultat.minimum";
+        public const string SokResultatNoekler = "no.ks.fiks.arkiv.v1.innsyn.sok.resultat.noekler";
           
         public static readonly List<string> ArkivmeldingTyper = new List<string>()
         {

--- a/KS.Fiks.IO.Arkiv.Client/Models/ArkivintegrasjonMeldingTypeV1.cs
+++ b/KS.Fiks.IO.Arkiv.Client/Models/ArkivintegrasjonMeldingTypeV1.cs
@@ -8,18 +8,18 @@ namespace KS.Fiks.IO.Arkiv.Client.Models
         public const string Mottatt = "no.ks.fiks.arkiv.v1.mottatt";
         public const string Kvittering = "no.ks.fiks.arkiv.v1.kvittering";
         
-        // Arkivmelding
-        public const string Arkivmelding = "no.ks.fiks.arkiv.v1.arkivmelding";
+        // Arkivering
+        public const string Arkivmelding = "no.ks.fiks.arkiv.v1.arkivering.arkivmelding";
         
-        //Hent
-        public const string MappeHent = "no.ks.fiks.arkiv.v1.mappe.hent";
-        public const string MappeHentResultat = "no.ks.fiks.arkiv.v1.mappe.hent.resultat";
-        public const string JournalpostHent = "no.ks.fiks.arkiv.v1.journalpost.hent";
-        public const string JournalpostHentResultat = "no.ks.fiks.arkiv.v1.journalpost.hent.resultat";
-        public const string DokumentfilHent = "no.ks.fiks.arkiv.v1.dokumentfil.hent";
-        public const string DokumentfilHentResultat = "no.ks.fiks.arkiv.v1.dokumentfil.hent.resultat";
+        // Innsyn Hent
+        public const string MappeHent = "no.ks.fiks.arkiv.v1.innsyn.mappe.hent";
+        public const string MappeHentResultat = "no.ks.fiks.arkiv.v1.innsyn.mappe.hent.resultat";
+        public const string JournalpostHent = "no.ks.fiks.arkiv.v1.innsyn.journalpost.hent";
+        public const string JournalpostHentResultat = "no.ks.fiks.arkiv.v1.innsyn.journalpost.hent.resultat";
+        public const string DokumentfilHent = "no.ks.fiks.arkiv.v1.innsyn.dokumentfil.hent";
+        public const string DokumentfilHentResultat = "no.ks.fiks.arkiv.v1.innsyn.dokumentfil.hent.resultat";
         
-        // Sok
+        // Innsyn Søk
         public const string Sok = "no.ks.fiks.arkiv.v1.innsyn.sok";
         public const string SokResultatUtvidet = "no.ks.fiks.arkiv.v1.innsyn.sok.resultat.utvidet";
         public const string SokResultatMinimum = "no.ks.fiks.arkiv.v1.innsyn.sok.resultat.minimum";


### PR DESCRIPTION
Vi ser at .innsyn begrepet i navnene i meldingstyper kan allikevel være nyttig for håndtering av kontotyper i Fiks-IO konfigurasjon. For å kunne vise meldingstyper som skal være for kontoer som bare skal bruke søk (innsyn). 

Men er hent meldingene for Dokument, Mappe og Journalpost av egen art? Har vi behov for noe tilsvarende .innsyn for dem eller har vi 2 typer? .innsyn og resten?